### PR TITLE
Missing dash on component type docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ The necessary files required for the new component are created for you automatic
 ### Component Types
 Astrum currently supports two component types. The default component and a **colors** type. The **colors** type lets you include a color palette in your pattern library and to include it you use the `—type` option:
 
-`astrum new branding/color-palette —type colors`
+`astrum new branding/color-palette -—type colors`
 
 ![](https://dl.dropboxusercontent.com/u/251342/astrum-gifs/astrum-new-colors.gif)
 


### PR DESCRIPTION
Us copy and paste learners where being tripped up on this.