### PR TITLE
Corrects documented order of commands to submit PR

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -51,15 +51,15 @@ The following process is the best way to get your work included:
 	# Clone your fork of the repo into the current directory
 	$ git clone https://github.com/<your-username>/astrum.git
 	```
-			
-	```bash  
-	# Assign the original repo to a remote called "upstream"
-	$ git remote add upstream https://github.com/nodivide/astrum.git
-	```
 			   
 	```bash		
 	# Navigate to the newly cloned directory
 	$ cd astrum
+	```
+			
+	```bash  
+	# Assign the original repo to a remote called "upstream"
+	$ git remote add upstream https://github.com/nodivide/astrum.git
 	```
 	   
 	```bash	   


### PR DESCRIPTION
#### What does this PR cover?

Small change to the documentation regarding order of commands to fork, clone, and submit a PR. Potential contributors were told to clone their fork, add the upstream branch to the cloned repo, and *then* change into the directory containing the repo. Step 2 can't happen until the user is in the project directory.

---

#### Reviewers

**Review 1**
- [ ] :+1:

**Review 2** _(optional)_
- [ ] :+1:


By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.

---

