### PR TITLE
resolving module_path with __dirname

### DIFF
--- a/manager/utils.js
+++ b/manager/utils.js
@@ -4,11 +4,12 @@ var fs = require('fs-extra'),
     dir = require('global-modules'),
     mkdirp = require('mkdirp'),
     isWindows = require('is-windows'),
-    pjson = require('../package.json');
+    pjson = require('../package.json'),
+    path = require('path');
 
 module.exports = {
 
-    module_path: dir + '/' + pjson.name,
+    module_path: path.resolve(`${__dirname}/..`),
     $root: process.cwd(),
     $config: null,
     $data: null,
@@ -84,7 +85,7 @@ module.exports = {
         fs.copy(_this.pathify(_this.module_path + '/_template/app'), _this.$config.path + '/app');
         fs.copy(_this.pathify(_this.module_path + '/_template/index.html'), _this.$config.path + '/index.html');
         fs.copy(_this.pathify(_this.module_path + '/_template/LICENSE.txt'), _this.$config.path + '/LICENSE.txt');
-        
+
         _this.updateVersion(pjson.version);
 
         /**
@@ -107,7 +108,7 @@ module.exports = {
 
     getConfig: function() {
         var _this = this;
-        
+
         return JSON.parse(fs.readFileSync(_this.pathify(_this.$root + '/astrum-config.json')));
     },
 

--- a/manager/utils.js
+++ b/manager/utils.js
@@ -1,7 +1,6 @@
 var fs = require('fs-extra'),
     chalk = require('chalk'),
     inquirer = require('inquirer'),
-    dir = require('global-modules'),
     mkdirp = require('mkdirp'),
     isWindows = require('is-windows'),
     pjson = require('../package.json'),

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "commander": "^2.9.0",
     "cwd": "^0.10.0",
     "fs-extra": "^0.28.0",
-    "global-modules": "^0.2.2",
     "inquirer": "^1.0.2",
     "is-windows": "^0.2.0",
     "mkdirp": "^0.5.1"


### PR DESCRIPTION
#### What does this PR cover?

Fixing the issue #64.

* required `path` - module in `manager/utils.js`
* resolving the module_path with `__dirname`

#### How can this be tested?

Initialize astrum pattern llibrary in arbitary folder (e.g. `astrum init ./pttrns/`)

#### Screenshots / Screencast
![astrum-fix-64-before](https://cloud.githubusercontent.com/assets/11672744/22489921/792728a6-e81a-11e6-86a5-58a026017c29.png)
![astrum-fix-64-after](https://cloud.githubusercontent.com/assets/11672744/22489920/7921f002-e81a-11e6-91c5-bd6118271d13.png)

---

#### Reviewers

**Review 1**
- [ ] :+1:

**Review 2** _(optional)_
- [ ] :+1:


By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.

---
