### PR TITLE
Fix code highlight bg override variable name

### DIFF
--- a/_template/index.html
+++ b/_template/index.html
@@ -42,7 +42,7 @@
             .ndpl-c-brand-cai a                  { color: {{ theme.brand_color }} !important; }
         </style>
         <link rel="stylesheet" v-if="theme.code_highlight_theme" :href="'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.3.0/styles/' + theme.code_highlight_theme + '.min.css'">
-        <style v-if="theme.override_code_highlight_bg">.hljs { background: {{ theme.highlight_color }}} !important; }</style>
+        <style v-if="theme.override_code_highlight_bg">.hljs { background: {{ theme.override_code_highlight_bg }}} !important; }</style>
         <link rel="stylesheet" href="app/css/styles.min.css">
 
         <!-- Font Libraries -->


### PR DESCRIPTION
#### What does this PR cover?
It fixes a wrong variable name for `override_code_highlight_bg` in the `index.html` file.

#### How can this be tested?
1. Make sure you have a light `code_highlight_theme` defined (the default `github` will work).
2. Change `override_code_highlight_bg` to a dark color (i.e. `#090B0C`).
3. Make sure you have a component with code sample defined.
4. Open the library pattern on the browser.
5. Click on "Show Code Sample" from any component to see that the defined background override is now applied.

#### Screenshots / Screencast
After following the above steps (but using `vs` as `code_highlight_theme`):

<img width="405" alt="screen shot 2017-03-05 at 09 12 31" src="https://cloud.githubusercontent.com/assets/210138/23585646/ea726a34-0183-11e7-8878-bf43370ca595.png">

#### Observation
I haven‘t created an issue before sending this PR (because of the simplicity of the change). To reproduce the error, you can follow the steps above and check that the dark background is not applied:

<img width="405" alt="screen shot 2017-03-05 at 09 17 45" src="https://cloud.githubusercontent.com/assets/210138/23585688/ef88bab8-0184-11e7-9f38-ce220ce86136.png">

---

#### Reviewers

**Review 1**
- [ ] :+1:

**Review 2** _(optional)_
- [ ] :+1:


By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.

---
