### PR TITLE
Enable use of common color keywords in color component

### DIFF
--- a/_template/app/js/main.js
+++ b/_template/app/js/main.js
@@ -154,6 +154,7 @@ var ndplComponent = Vue.extend({
             var rgb = this.$root.convertHexToRgb(hex),
                 brightness = this.$root.getColorBrightness(rgb);
 
+	        console.log("shouldInvertText::", rgb, hex);
             return brightness > 210;
         },
 
@@ -851,6 +852,10 @@ new Vue({
          * @returns {{r: number, g: number, b: number}}
          */
         convertHexToRgb: function(hex) {
+	        // Expand color names "black" and "white"
+	        if (hex === "black") hex = "#000";
+	        else if (hex === "white") hex = "#fff"
+
             // Expand shorthand form (e.g. "03F") to full form (e.g. "0033FF")
             var shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
             hex = hex.replace(shorthandRegex, function(m, r, g, b) {


### PR DESCRIPTION
If "white" is used as a value in a color component the component will be marked with the class `ndpl-dark-text` so the text and the border of the component will be visible.

The keyword `black` will also be converted to into a valid value.

#### How can this be tested?

Add `white` to the color array of an color component, e.g.:

```json
{
    "name": "colors",
    "title": "Colors",
    "components": [
        {
            "group": "colors",
            "name": "test-colors",
            "title": "Test Colors",
            "type": "colors",
            "colors": [
                "white",
                "black"
            ]
        }
    ]
}