### PR TITLE
Feature - extend init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Astrum
 
+***
+If you love Astrum why not come and work with us at [No Divide](http://nodividestudio.com)! We're on the lookout for a new developer to join our team. For full details visit [nodividestudio.com/vacancies](http://nodividestudio.com/vacancies).
+***
+
 ![](http://nodivide.imgix.net/astrum/header.jpg)
 
 Astrum is a lightweight pattern library designed to be included with any web project.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Astrum
 
-***
-If you love Astrum why not come and work with us at [No Divide](http://nodividestudio.com)! We're on the lookout for a new developer to join our team. For full details visit [nodividestudio.com/vacancies](http://nodividestudio.com/vacancies).
-***
-
 ![](http://nodivide.imgix.net/astrum/header.jpg)
 
 Astrum is a lightweight pattern library designed to be included with any web project.

--- a/manager/astrum-init.js
+++ b/manager/astrum-init.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-var Command = require('commander').Command,
-    program = require('commander'),
+var program = require('commander'),
     fs = require('fs-extra'),
     chalk = require('chalk'),
     inquirer = require('inquirer'),
@@ -10,11 +9,13 @@ program
     .usage('[path]')
     .description(chalk.yellow('Initilize a new pattern library.'));
 
+
+
 /**
  * Override argv[1] so that usage command is
  * formatted correctly.
  */
-process.argv[1] = 'patterns init';
+process.argv[1] = 'astrum init';
 
 program.parse(process.argv);
 

--- a/manager/utils.js
+++ b/manager/utils.js
@@ -4,11 +4,12 @@ var fs = require('fs-extra'),
     dir = require('global-modules'),
     mkdirp = require('mkdirp'),
     isWindows = require('is-windows'),
-    pjson = require('../package.json');
+    pjson = require('../package.json'),
+    path = require('path');
 
 module.exports = {
 
-    module_path: dir + '/' + pjson.name,
+    module_path: path.resolve(`${__dirname}/..`),
     $root: process.cwd(),
     $config: null,
     $data: null,
@@ -84,7 +85,7 @@ module.exports = {
         fs.copy(_this.pathify(_this.module_path + '/_template/app'), _this.$config.path + '/app');
         fs.copy(_this.pathify(_this.module_path + '/_template/index.html'), _this.$config.path + '/index.html');
         fs.copy(_this.pathify(_this.module_path + '/_template/LICENSE.txt'), _this.$config.path + '/LICENSE.txt');
-        
+
         _this.updateVersion(pjson.version);
 
         /**
@@ -117,7 +118,7 @@ module.exports = {
 
     getConfig: function() {
         var _this = this;
-        
+
         return JSON.parse(fs.readFileSync(_this.pathify(_this.$root + '/astrum-config.json')));
     },
 

--- a/manager/utils.js
+++ b/manager/utils.js
@@ -71,9 +71,9 @@ module.exports = {
          */
         if (fs.existsSync(path) === true){
 
-            console.log(chalk.grey('----------------------------------------------------------------'));
-            console.log(chalk.grey('\u26A0 Info: Pattern library detected in the given folder'));
-            console.log(chalk.grey('----------------------------------------------------------------'));
+            console.log(chalk.yellow('----------------------------------------------------------------'));
+            console.log(chalk.yellow('\u26A0 Info: Pattern library detected in the given folder'));
+            console.log(chalk.yellow('----------------------------------------------------------------'));
 
             inquirer.prompt(
                 {

--- a/manager/utils.js
+++ b/manager/utils.js
@@ -71,15 +71,15 @@ module.exports = {
          */
         if (fs.existsSync(path) === true){
 
-            console.log(chalk.yellow('----------------------------------------------------------------'));
-            console.log(chalk.yellow('\u26A0 Info: Pattern library detected in the given folder'));
-            console.log(chalk.yellow('----------------------------------------------------------------'));
+            console.log(chalk.red('----------------------------------------------------------------'));
+            console.log(chalk.red('\u26A0 Warning: Pattern library detected in the given folder'));
+            console.log(chalk.red('----------------------------------------------------------------'));
 
             inquirer.prompt(
                 {
                     type: 'confirm',
                     name: 'init_overwrite',
-                    message: 'This will copy/overwrite only the project idependent astrum files (html, css & js).\nDo you want to proceed?',
+                    message: 'This will copy/overwrite only the project independent astrum files (html, css & js).\nDo you want to proceed?',
                     default: true
                 }).then(function(answers){
 

--- a/manager/utils.js
+++ b/manager/utils.js
@@ -1,7 +1,6 @@
 var fs = require('fs-extra'),
     chalk = require('chalk'),
     inquirer = require('inquirer'),
-    dir = require('global-modules'),
     mkdirp = require('mkdirp'),
     isWindows = require('is-windows'),
     pjson = require('../package.json'),

--- a/manager/utils.js
+++ b/manager/utils.js
@@ -79,7 +79,7 @@ module.exports = {
                 {
                     type: 'confirm',
                     name: 'init_overwrite',
-                    message: 'This will copy/overwrite only the project independent astrum files (html, css & js).\nDo you want to proceed?',
+                    message: 'This will copy/overwrite only the project independent Astrum files (html, css & js).\nDo you want to proceed?',
                     default: true
                 }).then(function(answers){
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "commander": "^2.9.0",
     "cwd": "^0.10.0",
     "fs-extra": "^0.28.0",
-    "global-modules": "^0.2.2",
     "inquirer": "^1.0.2",
     "is-windows": "^0.2.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
#### What does this PR cover?
* Resolving module_path with __dirname (already merged in v1) #96 
* When init-ing don't overwrite pre-existing files (to aid the distribution of astrum projects) #66
* Add facility to initialise Astrum into a pre-existing folder. #23

This actually makes the tool more versatile, the way I see it there are  two fundamentally different approaches for using astrum:

1. Initializing the tool locally, commit all the generated files to be deployed in some way and served statically
2. Initializing the tool locally, setting the files without project specific data (index.html, main(.min).js and style(.min).css) in the .gitignore and generate them via a CI Server and then deploy it. 

By not being able to "re-init" astrum on an existing folder, the usage for group 2 is much more cumbersome. This pull request aims to solve that. 

#### How can this be tested?
Initialize the library in any directory, and then do it again.

#### Screenshots / Screencast
<img width="1302" alt="astrum-extend-init" src="https://user-images.githubusercontent.com/1641979/29467342-66ff229c-8440-11e7-9afc-c2d5f26e71d8.png">

---

#### Reviewers


**Review 1**
- [x] :+1:

**Review 2** _(optional)_
- [x] :+1:

By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
---
