### PR TITLE
Force trailing slash when page is loaded

### DIFF
--- a/_template/index.html
+++ b/_template/index.html
@@ -6,6 +6,12 @@
 
         <title v-text="project_name ? project_name + ' | Pattern Library' : 'Pattern Library'"></title>
 
+        <script>
+          if(location.pathname.slice(-1) !== '/') {
+            location.pathname += '/';
+          }
+        </script>
+
         <!-- Astrum (https://github.com/NoDivide/astrum) -->
         <meta name="application-name" content="Astrum {{ version }}" />
 


### PR DESCRIPTION
#### What does this PR cover?
When loading the pattern library root, if there is no trailing slash on the path name, then `app/js/main.min.js` will not load and the app breaks.

I've just added a tiny check in the `<head>` that forces the trailing slash if it is not present. Does not redirect or mess with hashes.

#### Screenshot
![broken app w/o trailing slash](https://user-images.githubusercontent.com/4140885/32378403-b2cdee14-c078-11e7-9748-2936d8d46432.png)

---

#### What gif best describes how you feel about this work?
![](https://media1.giphy.com/media/XreQmk7ETCak0/giphy.gif)

---

#### Reviewers

**Review 1**
- [ ] :+1:

**Review 2** _(optional)_
- [ ] :+1:


By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.

---
