### PR TITLE
Set the default option for a new group as 'Position after {last}'

### DIFF
--- a/manager/astrum-new.js
+++ b/manager/astrum-new.js
@@ -148,7 +148,8 @@ if (group_name) {
                         type: 'list',
                         name: 'group_position',
                         message: 'Select group position:',
-                        choices: utils.getGroupPositionChoices()
+                        choices: utils.getGroupPositionChoices(),
+                        default: (utils.getGroupPositionChoices().length - 1)
                     }
                 ]).then(function (answers) {
                     newGroup.name = parts[0];


### PR DESCRIPTION
#### What does this PR cover?
This is to fix #141.

#### How can this be tested?
- Create a new component in a new group: `astrum new test/default`
- Follow the instructions as usual
- When prompted with "Select group position: (Use arrow keys)", the selected option should be "Position after {last}". "{last}" is your last group

#### Screenshots / Screencast
<img width="717" alt="astrum-ss" src="https://user-images.githubusercontent.com/8672583/33183798-39512e3a-d071-11e7-8600-42295f308cf9.png">


#### What gif best describes how you feel about this work?
![Kenan from "Kenan and Kel" likes the smell of what's on his plate](https://user-images.githubusercontent.com/8672583/33183922-f256d330-d071-11e7-9029-d010c0b333c0.gif)

---

#### Reviewers

**Review 1**
- [ ] :+1:

**Review 2** _(optional)_
- [ ] :+1:


By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.

---
