### PR TITLE
Where a custom library_title is set, make sure it takes precedence ov…

### DIFF
--- a/_template/index.html
+++ b/_template/index.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width">
 
-        <title v-text="project_name ? project_name + ' | Pattern Library' : 'Pattern Library'"></title>
+        <title v-text="project_name ? project_name + ' | ' + (theme.titles.library_title ? theme.titles.library_title : 'Pattern Library') : 'Pattern Library'"></title>
 
         <!-- Astrum (https://github.com/NoDivide/astrum) -->
         <meta name="application-name" content="Astrum {{ version }}" />
@@ -67,7 +67,10 @@
             <div class="ndpl-cube3 ndpl-cube"></div>
         </div>
 
-        <h3 class="ndpl-loading__title" v-if="! loaded && !log.error.length && !log.info.length">Building pattern library...</h3>
+        <h3 class="ndpl-loading__title" v-if="! loaded && !log.error.length && !log.info.length">
+            <template v-if="theme.titles.library_title">Building {{ theme.titles.library_title }}...</template>
+            <template v-else>Building pattern library...</template>
+        </h3>
         <h3 class="ndpl-loading__title" v-if="log.error.length">Hold up! We have some errors...</h3>
         <h3 class="ndpl-loading__title" v-if="log.info.length && !log.error.length">Looks like you have some setup to do...</h3>
 
@@ -185,7 +188,9 @@
                         &copy; {{ copyright_year }} {{{ client }}}.
                     </template>
                     <template v-if="all_creators">
-                        <br/>Pattern library created by {{{ all_creators }}}.
+                        <br/>
+                        <template v-if="theme.titles.library_title">{{ theme.titles.library_title }} created by {{{ all_creators }}}.</template>
+                        <template v-else>Pattern library created by {{{ all_creators }}}.</template>
                     </template>
                 </p>
 


### PR DESCRIPTION
…er 'Pattern library'

#### What does this PR cover?
This PR fixes #104 

#### How can this be tested?
- Init Astrum
- Create at least one component 
- Open it in your browser and notice all the refs to 'Pattern library'
- Change `theme.titles.library_title` in `data.json` to something like 'Custom title'
- Refresh your browser and see the refs have change to 'Custom title'
- Celebrate enthusiastically 

#### Screenshots / Screencast
![nov-24-2017 16-42-58](https://user-images.githubusercontent.com/8672583/33218924-6ebf8618-d137-11e7-9602-0e72595da0d9.gif)

#### What gif best describes how you feel about this work?
![Soccer coach giving the thumbs up](https://media.giphy.com/media/l1J9x9U0uwC6YFoL6/giphy.gif)

---

#### Reviewers

**Review 1**
- [ ] :+1:

**Review 2** _(optional)_
- [ ] :+1:


By adding a +1 you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.

---